### PR TITLE
Remove macOS as a build image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run playbook
         run: |
           source env/bin/activate
-          ansible-playbook playbook.yml -vvv
+          ansible-playbook playbook.yml --tags=server,workstation,friend -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-12]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-12]
+        os: [ubuntu-20, ubuntu-22, macos-14]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,17 @@ on:
       - "feature/*"
       - "bugfix/*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20, ubuntu-22, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, fedora-latest]
+        os: [macos-latest, ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,21 @@ name: Matrix build on multiple operating systems
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "feature/*"
+      - "bugfix/*"
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - "main"
+      - "feature/*"
+      - "bugfix/*"
 
 jobs:
-
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, fedora-latest]
     steps:

--- a/README.md
+++ b/README.md
@@ -11,12 +11,17 @@ This repository contains Ansible playbooks to provision different types of machi
 
 1. [Install Ansible v2.x](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your local machine
 1. Clone this repository 
-1. Run: `ansible-playbook playbook.yml -vvv`
+1. Run: 
+   - Common packages: `ansible-playbook playbook.yml -vvv`
+   - Server packages: `ansible-playbook playbook.yml -vvv --tags=server`
+   - Workstation packages: `ansible-playbook playbook.yml -vvv --tags=workstation`
+   - Combination server + workstation packages: `ansible-playbook playbook.yml -vvv --tags=server,workstation`
+   - Friend packages: `ansible-playbook playbook.yml -vvv --tags=friend`
 
 ## Supported Platforms
 
 The playbooks are tested on:
-- macOS 
+- macOS
 - Fedora/RHEL
 - Debian/Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JP's Playbooks
 
-This repository contains Ansible playbooks to provision different types of machines:
+This repository contains Ansible playbooks to provision different types of Ubuntu machines:
 
 - Common: Base packages installed on all machines
 - Server: Packages for servers, imports common playbook 
@@ -17,11 +17,5 @@ This repository contains Ansible playbooks to provision different types of machi
    - Workstation packages: `ansible-playbook playbook.yml -vvv --tags=workstation`
    - Combination server + workstation packages: `ansible-playbook playbook.yml -vvv --tags=server,workstation`
    - Friend packages: `ansible-playbook playbook.yml -vvv --tags=friend`
-
-## Supported Platforms
-
-The playbooks are tested on:
-- Debian/Ubuntu
-- macOS
 
 Some packages are OS-specific and will only be installed if supported on the target platform.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This repository contains Ansible playbooks to provision different types of machi
 ## Supported Platforms
 
 The playbooks are tested on:
-- macOS
-- Fedora/RHEL
 - Debian/Ubuntu
+- macOS
 
 Some packages are OS-specific and will only be installed if supported on the target platform.

--- a/playbook.yml
+++ b/playbook.yml
@@ -5,14 +5,39 @@
     use_become: "{{ ansible_os_family != 'Darwin' }}"
 
   tasks:
-    - name: Install common
+    - name: Include variables
+      include_vars: "vars.yml"
+      tags: always
+
+    - name: Output names of packages to be installed for common role
+      debug:
+        var: packages
+      tags: always
+
+    - name: Install packages for common role
       become: "{{ use_become }}"
       ansible.builtin.package:
-        name:
-          - git
-          - vim
-          - htop
-          - xz-utils
-          - golang
-          - fail2ban
+        name: "{{ packages.common }}"
         state: present
+      tags: always
+
+    - name: Install packages for server role
+      become: "{{ use_become }}"
+      ansible.builtin.package:
+        name: "{{ packages.server }}"
+        state: present
+      tags: server
+
+    - name: Install packages for workstation role
+      become: "{{ use_become }}"
+      ansible.builtin.package:
+        name: "{{ packages.workstation }}"
+        state: present
+      tags: workstation
+
+    - name: Install packages for friend role
+      become: "{{ use_become }}"
+      ansible.builtin.package:
+        name: "{{ packages.friend }}"
+        state: present
+      tags: friend

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,10 +1,13 @@
 ---
 - hosts: all
-  become: yes
+
+  vars:
+    use_become: "{{ ansible_os_family != 'Darwin' }}"
 
   tasks:
     - name: Install common
       ansible.builtin.package:
+        become: "{{ use_become }}"
         name:
           - git
           - vim

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,8 +6,8 @@
 
   tasks:
     - name: Install common
+      become: "{{ use_become }}"
       ansible.builtin.package:
-        become: "{{ use_become }}"
         name:
           - git
           - vim

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -1,0 +1,16 @@
+---
+packages:
+  common:
+    - git
+    - vim
+    - htop
+
+  friend:
+    - libreoffice
+
+  server:
+    - fail2ban
+
+  workstation:
+    - nginx
+    - docker

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -6,7 +6,7 @@ packages:
     - htop
 
   friend:
-    - libreoffice
+    - vlc
 
   server:
     - fail2ban


### PR DESCRIPTION
Built-in brew package management adapter isn't as straightforward as it seems.